### PR TITLE
Support CRLF line endings

### DIFF
--- a/prettier-config.js
+++ b/prettier-config.js
@@ -1,6 +1,7 @@
 module.exports = {
   trailingComma: "es5",
   jsxBracketSameLine: true,
+  endOfLine: "auto",
   printWidth: 130,
-  arrowParens: "avoid"
+  arrowParens: "avoid",
 };


### PR DESCRIPTION
As git automatically sets line endings to CRLF on Windows platform, the current Prettier configuration marks all files with warnings.
This PR changes the Prettier configuration to support any line endings provided that they are consistent within each file.